### PR TITLE
feat: 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-sticker-bot",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/src/aws/stack.js
+++ b/src/aws/stack.js
@@ -86,24 +86,29 @@ export class TagStickerBotStack extends cdk.Stack {
     if (!isProduction) new cdk.CfnOutput(this, 'debugUrl', { value: debugUrl })
   }
 
-  createUserSessionsTable() {
-    return new cdk.aws_dynamodb.Table(this, 'userSessionsTable', {
-      tableName: `${appName}-${environment}-user-sessions`,
-      partitionKey: { name: 'userId', type: cdk.aws_dynamodb.AttributeType.STRING },
-      billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    })
-  }
-
   createTagsTable() {
     return new cdk.aws_dynamodb.Table(this, 'tagsTable', {
       tableName: `${appName}-${environment}-tags`,
       partitionKey: { name: 'stickerFileUniqueId', type: cdk.aws_dynamodb.AttributeType.STRING },
       sortKey: { name: 'authorUserId', type: cdk.aws_dynamodb.AttributeType.STRING },
-      billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST,
+      billingMode: cdk.aws_dynamodb.BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
       removalPolicy: isProduction
         ? cdk.RemovalPolicy.RETAIN
         : cdk.RemovalPolicy.DESTROY,
+    })
+  }
+
+  createUserSessionsTable() {
+    return new cdk.aws_dynamodb.Table(this, 'userSessionsTable', {
+      tableName: `${appName}-${environment}-user-sessions`,
+      partitionKey: { name: 'userId', type: cdk.aws_dynamodb.AttributeType.STRING },
+      billingMode: cdk.aws_dynamodb.BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      timeToLiveAttribute: 'expiresAt',
     })
   }
 
@@ -112,8 +117,11 @@ export class TagStickerBotStack extends cdk.Stack {
       tableName: `${appName}-${environment}-queued-stickers`,
       partitionKey: { name: 'userId', type: cdk.aws_dynamodb.AttributeType.STRING },
       sortKey: { name: 'stickerFileUniqueId', type: cdk.aws_dynamodb.AttributeType.STRING },
-      billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST,
+      billingMode: cdk.aws_dynamodb.BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
+      timeToLiveAttribute: 'expiresAt',
     })
   }
 }

--- a/src/aws/stack.js
+++ b/src/aws/stack.js
@@ -89,8 +89,8 @@ export class TagStickerBotStack extends cdk.Stack {
   createTagsTable() {
     return new cdk.aws_dynamodb.Table(this, 'tagsTable', {
       tableName: `${appName}-${environment}-tags`,
-      partitionKey: { name: 'stickerFileUniqueId', type: cdk.aws_dynamodb.AttributeType.STRING },
-      sortKey: { name: 'authorUserId', type: cdk.aws_dynamodb.AttributeType.STRING },
+      partitionKey: { name: 'uid', type: cdk.aws_dynamodb.AttributeType.STRING },
+      sortKey: { name: 'author', type: cdk.aws_dynamodb.AttributeType.STRING },
       billingMode: cdk.aws_dynamodb.BillingMode.PROVISIONED,
       readCapacity: 1,
       writeCapacity: 1,
@@ -103,25 +103,25 @@ export class TagStickerBotStack extends cdk.Stack {
   createUserSessionsTable() {
     return new cdk.aws_dynamodb.Table(this, 'userSessionsTable', {
       tableName: `${appName}-${environment}-user-sessions`,
-      partitionKey: { name: 'userId', type: cdk.aws_dynamodb.AttributeType.STRING },
+      partitionKey: { name: 'user', type: cdk.aws_dynamodb.AttributeType.STRING },
       billingMode: cdk.aws_dynamodb.BillingMode.PROVISIONED,
       readCapacity: 1,
       writeCapacity: 1,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
-      timeToLiveAttribute: 'expiresAt',
+      timeToLiveAttribute: 'exp',
     })
   }
 
   createQueuedStickersTable() {
     return new cdk.aws_dynamodb.Table(this, 'queuedStickersTable', {
       tableName: `${appName}-${environment}-queued-stickers`,
-      partitionKey: { name: 'userId', type: cdk.aws_dynamodb.AttributeType.STRING },
-      sortKey: { name: 'stickerFileUniqueId', type: cdk.aws_dynamodb.AttributeType.STRING },
+      partitionKey: { name: 'user', type: cdk.aws_dynamodb.AttributeType.STRING },
+      sortKey: { name: 'uid', type: cdk.aws_dynamodb.AttributeType.STRING },
       billingMode: cdk.aws_dynamodb.BillingMode.PROVISIONED,
       readCapacity: 1,
       writeCapacity: 1,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
-      timeToLiveAttribute: 'expiresAt',
+      timeToLiveAttribute: 'exp',
     })
   }
 }

--- a/src/bot/createBot.js
+++ b/src/bot/createBot.js
@@ -51,7 +51,6 @@ export async function createBot({
 
   await bot.telegram.setMyCommands([
     { command: 'start',  description: 'Get help' },
-    { command: 'stop',  description: 'Clear the queue' },
   ])
 
   bot.use(withUserId)
@@ -61,7 +60,6 @@ export async function createBot({
   bot.on(message('text'), handleTag)
 
   bot.start(start)
-  bot.command('stop', clearQueue)
   bot.command('version', version)
 
   bot.action('queue:skip', skipQueue)

--- a/src/bot/flows/search.js
+++ b/src/bot/flows/search.js
@@ -1,3 +1,4 @@
+import { INLINE_QUERY_CACHE_TIME_LOCAL_S, INLINE_QUERY_CACHE_TIME_S, INLINE_QUERY_RESULT_LIMIT, MAX_QUERY_LENGTH, MIN_QUERY_LENGTH } from '../../constants.js'
 import { isLocalTesting } from '../../env.js'
 
 /** @typedef {import('telegraf').Context} Context */
@@ -16,9 +17,13 @@ export function useSearchFlow({ stickerFinder }) {
     const authorUserId = context.inlineQuery.query.startsWith('!') ? userId : undefined
     const query = context.inlineQuery.query.slice(authorUserId ? 1 : 0)
 
-    if (query.length < 2 || query.length > 20) return
+    if (query.length < MIN_QUERY_LENGTH || query.length > MAX_QUERY_LENGTH) return
 
-    const stickers = await stickerFinder.find({ query, authorUserId, limit: 50 })
+    const stickers = await stickerFinder.find({
+      query,
+      authorUserId,
+      limit: INLINE_QUERY_RESULT_LIMIT,
+    })
 
     await context.answerInlineQuery(
       stickers.map((sticker, i) => ({
@@ -27,7 +32,9 @@ export function useSearchFlow({ stickerFinder }) {
         sticker_file_id: sticker.fileId,
       })),
       {
-        cache_time: isLocalTesting ? 5 : 300,
+        cache_time: isLocalTesting
+          ? INLINE_QUERY_CACHE_TIME_LOCAL_S
+          : INLINE_QUERY_CACHE_TIME_S,
         is_personal: Boolean(authorUserId),
         switch_pm_text: "Can't find a sticker? Click here to contribute",
         switch_pm_parameter: 'stub', // for some reason it fails if not provided

--- a/src/bot/flows/tagging.js
+++ b/src/bot/flows/tagging.js
@@ -1,3 +1,5 @@
+import { MAX_TAG_VALUE_LENGTH, MIN_TAG_VALUE_LENGTH } from '../../constants.js'
+
 /** @typedef {import('telegraf').Context} Context */
 
 /**
@@ -23,7 +25,7 @@ export function useTaggingFlow({ queuedStickerRepository, userSessionRepository,
     const value = context.message.text.trim().toLowerCase()
     if (!value) return
 
-    if (value.length < 2 || value.length > 100) {
+    if (value.length < MIN_TAG_VALUE_LENGTH || value.length > MAX_TAG_VALUE_LENGTH) {
       await context.reply(`❌ The tag is too short or too long, please try again`)
       return
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,4 +4,4 @@ export const MIN_TAG_VALUE_LENGTH = 2
 export const MAX_TAG_VALUE_LENGTH = 100
 export const INLINE_QUERY_CACHE_TIME_LOCAL_S = 5
 export const INLINE_QUERY_CACHE_TIME_S = 300
-export const INLINE_QUERY_RESULT_LIMIT = 2
+export const INLINE_QUERY_RESULT_LIMIT = 50

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,7 @@
+export const MIN_QUERY_LENGTH = 2
+export const MAX_QUERY_LENGTH = 20
+export const MIN_TAG_VALUE_LENGTH = 2
+export const MAX_TAG_VALUE_LENGTH = 100
+export const INLINE_QUERY_CACHE_TIME_LOCAL_S = 5
+export const INLINE_QUERY_CACHE_TIME_S = 300
+export const INLINE_QUERY_RESULT_LIMIT = 2

--- a/src/queue/DynamodbQueuedStickerRepository.js
+++ b/src/queue/DynamodbQueuedStickerRepository.js
@@ -1,5 +1,7 @@
 import { BatchWriteItemCommand, DeleteItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb'
 
+const BATCH_WRITE_ITEM_LIMIT = 25
+
 export class DynamodbQueuedStickerRepository {
   /**
    * @param {{
@@ -19,7 +21,7 @@ export class DynamodbQueuedStickerRepository {
    * }} input
    */
   async enqueue({ userId, stickers }) {
-    for (let i = 0; i < stickers.length; i += 25) {
+    for (let i = 0; i < stickers.length; i += BATCH_WRITE_ITEM_LIMIT) {
       await this._dynamodbClient.send(
         new BatchWriteItemCommand({
           RequestItems: {
@@ -88,12 +90,12 @@ export class DynamodbQueuedStickerRepository {
 
       if (Items.length === 0) continue
 
-      for (let i = 0; i < Items.length; i += 25) {
+      for (let i = 0; i < Items.length; i += BATCH_WRITE_ITEM_LIMIT) {
         await this._dynamodbClient.send(
           new BatchWriteItemCommand({
             RequestItems: {
               [this._tableName]: Items
-                .slice(i, i + 25)
+                .slice(i, i + BATCH_WRITE_ITEM_LIMIT)
                 .map(item => ({
                   DeleteRequest: {
                     Key: {

--- a/src/scripts/setup-local.js
+++ b/src/scripts/setup-local.js
@@ -1,5 +1,5 @@
 import { dynamodbQueuedStickersTable, dynamodbTagsTable, dynamodbUserSessionsTable } from '../env.js'
-import { CreateTableCommand, DeleteTableCommand } from '@aws-sdk/client-dynamodb'
+import { BillingMode, CreateTableCommand, DeleteTableCommand, DescribeTimeToLiveCommand, UpdateTimeToLiveCommand } from '@aws-sdk/client-dynamodb'
 import { createDynamodbClient } from '../utils/createDynamodbClient.js'
 
 const dynamodbClient = createDynamodbClient()
@@ -16,9 +16,19 @@ await dynamodbClient.send(
       AttributeName: 'userId',
       AttributeType: 'S'
     }],
+    BillingMode: BillingMode.PROVISIONED,
     ProvisionedThroughput: {
       ReadCapacityUnits: 1,
       WriteCapacityUnits: 1,
+    },
+  })
+)
+await dynamodbClient.send(
+  new UpdateTimeToLiveCommand({
+    TableName: dynamodbUserSessionsTable,
+    TimeToLiveSpecification: {
+      AttributeName: 'expiresAt',
+      Enabled: true,
     }
   })
 )
@@ -41,9 +51,19 @@ await dynamodbClient.send(
       AttributeName: 'userId',
       AttributeType: 'S'
     }],
+    BillingMode: BillingMode.PROVISIONED,
     ProvisionedThroughput: {
       ReadCapacityUnits: 1,
       WriteCapacityUnits: 1,
+    }
+  })
+)
+await dynamodbClient.send(
+  new UpdateTimeToLiveCommand({
+    TableName: dynamodbQueuedStickersTable,
+    TimeToLiveSpecification: {
+      AttributeName: 'expiresAt',
+      Enabled: true,
     }
   })
 )
@@ -66,6 +86,7 @@ await dynamodbClient.send(
       AttributeName: 'authorUserId',
       AttributeType: 'S'
     }],
+    BillingMode: BillingMode.PROVISIONED,
     ProvisionedThroughput: {
       ReadCapacityUnits: 1,
       WriteCapacityUnits: 1,

--- a/src/scripts/setup-local.js
+++ b/src/scripts/setup-local.js
@@ -9,11 +9,11 @@ await dynamodbClient.send(
   new CreateTableCommand({
     TableName: dynamodbUserSessionsTable,
     KeySchema: [{
-      AttributeName: 'userId',
+      AttributeName: 'user',
       KeyType: 'HASH'
     }],
     AttributeDefinitions: [{
-      AttributeName: 'userId',
+      AttributeName: 'user',
       AttributeType: 'S'
     }],
     BillingMode: BillingMode.PROVISIONED,
@@ -27,7 +27,7 @@ await dynamodbClient.send(
   new UpdateTimeToLiveCommand({
     TableName: dynamodbUserSessionsTable,
     TimeToLiveSpecification: {
-      AttributeName: 'expiresAt',
+      AttributeName: 'exp',
       Enabled: true,
     }
   })
@@ -38,17 +38,17 @@ await dynamodbClient.send(
   new CreateTableCommand({
     TableName: dynamodbQueuedStickersTable,
     KeySchema: [{
-      AttributeName: 'userId',
+      AttributeName: 'user',
       KeyType: 'HASH'
     }, {
-      AttributeName: 'stickerFileUniqueId',
+      AttributeName: 'uid',
       KeyType: 'RANGE'
     }],
     AttributeDefinitions: [{
-      AttributeName: 'stickerFileUniqueId',
+      AttributeName: 'uid',
       AttributeType: 'S'
     }, {
-      AttributeName: 'userId',
+      AttributeName: 'user',
       AttributeType: 'S'
     }],
     BillingMode: BillingMode.PROVISIONED,
@@ -62,7 +62,7 @@ await dynamodbClient.send(
   new UpdateTimeToLiveCommand({
     TableName: dynamodbQueuedStickersTable,
     TimeToLiveSpecification: {
-      AttributeName: 'expiresAt',
+      AttributeName: 'exp',
       Enabled: true,
     }
   })
@@ -73,17 +73,17 @@ await dynamodbClient.send(
   new CreateTableCommand({
     TableName: dynamodbTagsTable,
     KeySchema: [{
-      AttributeName: 'stickerFileUniqueId',
+      AttributeName: 'uid',
       KeyType: 'HASH'
     }, {
-      AttributeName: 'authorUserId',
+      AttributeName: 'author',
       KeyType: 'RANGE'
     }],
     AttributeDefinitions: [{
-      AttributeName: 'stickerFileUniqueId',
+      AttributeName: 'uid',
       AttributeType: 'S'
     }, {
-      AttributeName: 'authorUserId',
+      AttributeName: 'author',
       AttributeType: 'S'
     }],
     BillingMode: BillingMode.PROVISIONED,

--- a/src/tags/DynamodbTagRepository.js
+++ b/src/tags/DynamodbTagRepository.js
@@ -1,6 +1,7 @@
 import { BatchGetItemCommand, BatchWriteItemCommand, PutItemCommand, QueryCommand, ScanCommand } from '@aws-sdk/client-dynamodb'
 
 const DEFAULT_AUTHOR_USER_ID = '#default'
+const BATCH_GET_ITEM_LIMIT = 100
 
 // TODO: do not return duplicates in responses
 export class DynamodbTagRepository {
@@ -48,13 +49,13 @@ export class DynamodbTagRepository {
     /** @type {import('../types.d.ts').Tag[]} */
     const tags = []
 
-    for (let i = 0; i < stickerFileUniqueIds.length; i += 100) {
+    for (let i = 0; i < stickerFileUniqueIds.length; i += BATCH_GET_ITEM_LIMIT) {
       const { Responses } = await this._dynamodbClient.send(
         new BatchGetItemCommand({
           RequestItems: {
             [this._tableName]: {
               Keys: stickerFileUniqueIds
-                .slice(i, i + 100)
+                .slice(i, i + BATCH_GET_ITEM_LIMIT)
                 .map((stickerFileUniqueId) => ({
                   authorUserId: { S: authorUserId || DEFAULT_AUTHOR_USER_ID },
                   stickerFileUniqueId: { S: stickerFileUniqueId },

--- a/src/users/DynamodbUserSessionRepository.js
+++ b/src/users/DynamodbUserSessionRepository.js
@@ -1,4 +1,7 @@
 import { DeleteItemCommand, GetItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb'
+import { calculateExpiresAt } from '../utils/calculateExpiresAt.js'
+
+const EXPIRATION_TIME_S = 60 * 60 // 1 hour
 
 export class DynamodbUserSessionRepository {
   /**
@@ -23,8 +26,15 @@ export class DynamodbUserSessionRepository {
       new PutItemCommand({
         TableName: this._tableName,
         Item: {
-          userId: { S: userId },
-          context: { S: JSON.stringify({ ...oldContext, ...newContext }) },
+          userId: {
+            S: userId,
+          },
+          context: {
+            S: JSON.stringify({ ...oldContext, ...newContext }),
+          },
+          expiresAt: {
+            N: String(calculateExpiresAt(EXPIRATION_TIME_S)),
+          }
         }
       })
     )

--- a/src/users/DynamodbUserSessionRepository.js
+++ b/src/users/DynamodbUserSessionRepository.js
@@ -26,13 +26,13 @@ export class DynamodbUserSessionRepository {
       new PutItemCommand({
         TableName: this._tableName,
         Item: {
-          userId: {
+          user: {
             S: userId,
           },
-          context: {
+          ctx: {
             S: JSON.stringify({ ...oldContext, ...newContext }),
           },
-          expiresAt: {
+          exp: {
             N: String(calculateExpiresAt(EXPIRATION_TIME_S)),
           }
         }
@@ -45,7 +45,7 @@ export class DynamodbUserSessionRepository {
       new DeleteItemCommand({
         TableName: this._tableName,
         Key: {
-          userId: { S: userId }
+          user: { S: userId }
         }
       })
     )
@@ -57,11 +57,11 @@ export class DynamodbUserSessionRepository {
       new GetItemCommand({
         TableName: this._tableName,
         Key: {
-          userId: { S: userId }
+          user: { S: userId }
         }
       })
     )
 
-    return Item?.context?.S ? JSON.parse(Item.context.S) : {}
+    return Item?.ctx?.S ? JSON.parse(Item.ctx.S) : {}
   }
 }

--- a/src/utils/calculateExpiresAt.js
+++ b/src/utils/calculateExpiresAt.js
@@ -1,0 +1,3 @@
+export function calculateExpiresAt(expirationTimeS) {
+  return Math.floor(Date.now() / 1000) + expirationTimeS
+}


### PR DESCRIPTION
- Remove /stop command
- Implement scan filtering and limiting on DynamoDB side
- Add TTL for user sessions and sticker queue
- Make attribute names short for each table
- Don't store unnecessary data for default tags
- Move magic numbers to a separate file
- Use provisioned billing mode with 1 RCU/WCU